### PR TITLE
Fixes various compile- and run-time issues.

### DIFF
--- a/DinoLauncher/MainForm.xeto
+++ b/DinoLauncher/MainForm.xeto
@@ -83,7 +83,6 @@
           Size="140,64"
           TextColor="White"
           MouseUp="UseHQModels_MouseUp"
-        CheckBox_Use16MBRam
         />
 
       <!-- Shadow Buffer Size, Malloc -->

--- a/DinoLauncher/MainForm.xeto.cs
+++ b/DinoLauncher/MainForm.xeto.cs
@@ -346,11 +346,11 @@ public class MainForm : Form
             stream.Position = 0x4E084;
             Debug.WriteLine($"Old RAM Table Value: 0x0004E084 0x{stream.ReadByte()} ");
 
-	    uint shdwBuffer = 0x3C040002
-     	    var bytes = BitConverter.GetBytes(shdwBuffer)
+            uint shdwBuffer = 0x3C040002;
+            var bytes = BitConverter.GetBytes(shdwBuffer);
 	  
             stream.Position = 0x4E084;
-            stream.WriteByte(bytes);
+            stream.Write(bytes);
 
             stream.Position = 0x4E084;
             Debug.WriteLine($"New RAM Table Value: 0x0004E084 0x{stream.ReadByte()} ");

--- a/DinoLauncherLib/UserPrefs.cs
+++ b/DinoLauncherLib/UserPrefs.cs
@@ -72,7 +72,7 @@ public class UserPrefs
             new JProperty("UpdateBranch", UpdateBranch),
             new JProperty("OriginalRomPath", OriginalRomPath),
             new JProperty("PatchedRomPath", PatchedRomPath),
-            new JProperty("UseHQModels", UseHQModels)
+            new JProperty("UseHQModels", UseHQModels),
             new JProperty("Use16MBRam", Use16MBRam)
             );
 


### PR DESCRIPTION
The missing commas and semicolons and incorrect method signature prevent this codebase from building. Fixing those issues still yields a runtime exception, which is fixed by the change in MainForm.xeto.